### PR TITLE
fix: use exerpt instead of description

### DIFF
--- a/src/components/CourseItem.jsx
+++ b/src/components/CourseItem.jsx
@@ -48,7 +48,7 @@ const CourseItem = ({ course }) => {
           {course.authors.map(authorRenderer)}
         </p>
 
-        <p className="course-item__description">{course.description}</p>
+        <p className="course-item__description">{course.excerpt}</p>
       </div>
     </article>
   );


### PR DESCRIPTION
## DESCRIPTION

<img width="1435" alt="screen shot 2018-02-27 at 18 36 02" src="https://user-images.githubusercontent.com/727577/36744434-1d579652-1bed-11e8-9f55-5107beef8030.png">

(resolves #25)

## RECETTE

`yarn start`